### PR TITLE
Fix syntax of getSize() in setGltfContents

### DIFF
--- a/web/js/index.js
+++ b/web/js/index.js
@@ -118,7 +118,7 @@ const initThreeJsElements = function() {
             camera.far = size * 100;
             camera.updateProjectionMatrix();
             camera.position.copy(center);
-            const boxSize = box.getSize();
+            const boxSize = box.getSize(new Vector3());
             camera.position.x = boxSize.x * 2;
             camera.position.y = boxSize.y * 2;
             camera.position.z = boxSize.z * 2;


### PR DESCRIPTION
Hello, I noticed a small typo in `index.js` - according to the [Three.js docs](https://threejs.org/docs/#api/en/math/Box3.getSize), the `getSize()` always takes in a `Vector3` object as a parameter.

This is the way we call the function on line 107 of this file, so I figured I ought to just copy-paste the correct syntax downwards.