### PR TITLE
Fixed OAuth Issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,11 @@ app.get('/grantDenied', (req, res) => {
 })
 
 app.get('/', (req, res) => {
-    res.sendFile(path.join(__dirname, 'public', 'html', 'index.html'));
+    if (!req.user) {
+        return res.redirect(`/oauthSignin${req._parsedUrl.search}`);
+    } else {
+        return res.sendFile(path.join(__dirname, 'public', 'html', 'index.html'));
+    }
 });
 
 app.use('/api', require('./api'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,16 +5,15 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "app-gltf-viewer",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "connect-redis": "^5.0.0",
         "express": "^4.17.1",
         "express-session": "^1.17.1",
         "node-fetch": "^2.6.1",
         "passport": "^0.4.1",
         "passport-onshape": "^1.1.2",
-        "redis": "^3.1.1",
         "three": "^0.125.0",
         "uuid": "^8.3.1"
       },
@@ -422,14 +421,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/connect-redis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-5.0.0.tgz",
-      "integrity": "sha512-R4nTW5uXeG5s6zr/q4abmtcdloglZrL/A3cpa0JU0RLFJU4mTR553HUY8OZ0ngeySkGDclwQ5xmCcjjKkxdOSg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -485,14 +476,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -1378,42 +1361,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "node_modules/redis": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.1.tgz",
-      "integrity": "sha512-QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==",
-      "dependencies": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-redis"
-      }
-    },
-    "node_modules/redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-    },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      }
-    },
     "node_modules/regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -2137,11 +2084,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "connect-redis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-5.0.0.tgz",
-      "integrity": "sha512-R4nTW5uXeG5s6zr/q4abmtcdloglZrL/A3cpa0JU0RLFJU4mTR553HUY8OZ0ngeySkGDclwQ5xmCcjjKkxdOSg=="
-    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -2195,11 +2137,6 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
-    },
-    "denque": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
-      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -3021,35 +2958,6 @@
         "http-errors": "1.7.2",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "redis": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.1.tgz",
-      "integrity": "sha512-QhkKhOuzhogR1NDJfBD34TQJz2ZJwDhhIC6ZmvpftlmfYShHHQXjjNspAJ+Z2HH5NwSBVYBVganbiZ8bgFMHjg==",
-      "requires": {
-        "denque": "^1.5.0",
-        "redis-commands": "^1.7.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0"
-      }
-    },
-    "redis-commands": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
-      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
-    },
-    "redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
-    },
-    "redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
-      "requires": {
-        "redis-errors": "^1.0.0"
       }
     },
     "regexpp": {


### PR DESCRIPTION
Regression Issue from Previous Commit ([b9f7ff0](https://github.com/onshape-public/app-gltf-viewer/commit/b9f7ff0ce5e84e882161a9537efb1e730330ba60))

**Issue**
In addition to storing the translation state, Redis store was previously being used for storing the session's oauth access token (the store allowed it to persist between sessions). Therefore, issues were arising when restarting the Heroku application.

**Solution**
This is an ambiguous solution that a user could run on any hosting platform. The solution provided works by 'rerouting' to /oauthSignin as needed, which sets the session's state and user data and before loading any client code. 

In terms of the OAuth workflow, if a grant has not yet been provided the application reroutes to the Onshape sign-in page. If a grant has been provided, the application does not need to be rerouted to the Onshape sign-in page, yet the access token will be set to the user data.

This may be a temporary solution - as a sample application this needs to be a representation of how we want users to be implementing OAuth, and not sure if there is a better way. 